### PR TITLE
Update multiple_steps.py

### DIFF
--- a/dags/multiple_steps.py
+++ b/dags/multiple_steps.py
@@ -53,14 +53,14 @@ with DAG(
 ) as dag:
     cluster_creator = EmrCreateJobFlowOperator(
         task_id='create_job_flow',
-        job_flow_overrides=get_object('job_flow_overrides/job_flow_overrides.json', work_bucket)
+        job_flow_overrides=get_object('jobs/job_flow_overrides.json', work_bucket)
     )
 
     step_adder = EmrAddStepsOperator(
         task_id='add_steps',
         job_flow_id="{{ task_instance.xcom_pull(task_ids='create_job_flow', key='return_value') }}",
         aws_conn_id='aws_default',
-        steps=get_object('emr_steps/emr_steps.json', work_bucket)
+        steps=get_object('jobs/emr_steps.json', work_bucket)
     )
 
     step_checker = EmrStepSensor(


### PR DESCRIPTION
I have been following and using the steps in your incredible blog post -> https://itnext.io/running-spark-jobs-on-amazon-emr-with-apache-airflow-2e16647fea0c

In the steps where you deploy/use the multiple_steps.py dag, this did not match to this script . The folders are incorrect based on the blog post instructions of where to deploy the emr_steps.json and job_flow_overrides.json

The PR is to amend that so the match.